### PR TITLE
[Feature #16] 모든 refs와 관련 commits 출력 기능 구현

### DIFF
--- a/src/main/java/base/MiniGitCore.java
+++ b/src/main/java/base/MiniGitCore.java
@@ -200,6 +200,13 @@ public class MiniGitCore {
         return Repository.hashObject(commitData.toString(), "commit");
     }
 
+    public static void listRefs() {
+        Map<String, String> refs = Repository.iterRefs();
+        for (Map.Entry<String, String> ref : refs.entrySet()) {
+            System.out.println(ref.getKey() + " " + ref.getValue());
+        }
+    }
+
     private static void clearWorkingDirectory() {
         try {
             Files.walkFileTree(Paths.get("."), new SimpleFileVisitor<Path>() {

--- a/src/main/java/base/MiniGitCore.java
+++ b/src/main/java/base/MiniGitCore.java
@@ -204,6 +204,24 @@ public class MiniGitCore {
         return Repository.iterRefs();
     }
 
+    public static List<String> listCommits(Set<String> oids) {
+        Set<String> visited = new HashSet<>();
+        Deque<String> stack = new ArrayDeque<>(oids);
+        while (!stack.isEmpty()) {
+            String oid = stack.pop();
+            if (oid == null || visited.contains(oid)) {
+                continue;
+            }
+            visited.add(oid);
+
+            Commit commit = getCommit(oid);
+            if (commit.parent != null) {
+                stack.add(commit.parent);
+            }
+        }
+        return new ArrayList<>(visited);
+    }
+
     private static void clearWorkingDirectory() {
         try {
             Files.walkFileTree(Paths.get("."), new SimpleFileVisitor<Path>() {

--- a/src/main/java/base/MiniGitCore.java
+++ b/src/main/java/base/MiniGitCore.java
@@ -200,11 +200,8 @@ public class MiniGitCore {
         return Repository.hashObject(commitData.toString(), "commit");
     }
 
-    public static void listRefs() {
-        Map<String, String> refs = Repository.iterRefs();
-        for (Map.Entry<String, String> ref : refs.entrySet()) {
-            System.out.println(ref.getKey() + " " + ref.getValue());
-        }
+    public static Map<String, String> listRefs() {
+        return Repository.iterRefs();
     }
 
     private static void clearWorkingDirectory() {

--- a/src/main/java/cli/CLI.java
+++ b/src/main/java/cli/CLI.java
@@ -12,7 +12,8 @@ import picocli.CommandLine;
                 CommitCommand.class,
                 LogCommand.class,
                 CheckoutCommand.class,
-                TagCommand.class
+                TagCommand.class,
+                KCommand.class
         })
 public class CLI {
     public static void run() {

--- a/src/main/java/cli/KCommand.java
+++ b/src/main/java/cli/KCommand.java
@@ -7,6 +7,6 @@ import picocli.CommandLine;
 public class KCommand implements Runnable {
     @Override
     public void run() {
-        // MiniGitCore 메서드
+        MiniGitCore.listRefs();
     }
 }

--- a/src/main/java/cli/KCommand.java
+++ b/src/main/java/cli/KCommand.java
@@ -3,10 +3,15 @@ package cli;
 import base.MiniGitCore;
 import picocli.CommandLine;
 
+import java.util.Map;
+
 @CommandLine.Command(name = "k", description = "show all refs")
 public class KCommand implements Runnable {
     @Override
     public void run() {
-        MiniGitCore.listRefs();
+        Map<String, String> refs = MiniGitCore.listRefs();
+        for (Map.Entry<String, String> ref : refs.entrySet()) {
+            System.out.println(ref.getKey() + " " + ref.getValue());
+        }
     }
 }

--- a/src/main/java/cli/KCommand.java
+++ b/src/main/java/cli/KCommand.java
@@ -1,8 +1,11 @@
 package cli;
 
+import base.Commit;
 import base.MiniGitCore;
 import picocli.CommandLine;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 @CommandLine.Command(name = "k", description = "show all refs")
@@ -10,8 +13,15 @@ public class KCommand implements Runnable {
     @Override
     public void run() {
         Map<String, String> refs = MiniGitCore.listRefs();
+        System.out.println("--Refs--");
         for (Map.Entry<String, String> ref : refs.entrySet()) {
             System.out.println(ref.getKey() + " " + ref.getValue());
+        }
+
+        List<String> commits = MiniGitCore.listCommits(new HashSet<>(refs.values()));
+        System.out.println("\n--Commits--");
+        for (String oid : commits) {
+            System.out.println("Commit: " + oid);
         }
     }
 }

--- a/src/main/java/cli/KCommand.java
+++ b/src/main/java/cli/KCommand.java
@@ -1,0 +1,12 @@
+package cli;
+
+import base.MiniGitCore;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "k", description = "show all refs")
+public class KCommand implements Runnable {
+    @Override
+    public void run() {
+        // MiniGitCore 메서드
+    }
+}


### PR DESCRIPTION
# 📝 작업 내용

### 1. k 명령어 구현
- 모든 참조(refs)를 출력하는 명령어
- 해당 참조에서 도달할 수 있는 모든 commit-OID도 출력
- commit-OID는 여러 참조에서 도달할 수 있더라도 한 번만 반환(중복x)
```bash
./gradlew run --args=”k”
```
```bash
# 결과
--Refs--
HEAD f12bf00d0997e7fa988a5f55b19066c3bab27940
refs/tags/first aec774a8150c127f89469dc5e07b60cc0528d5d5
   ...

--Commits--
Commit: f12bf00d0997e7fa988a5f55b19066c3bab27940
Commit: aec774a8150c127f89469dc5e07b60cc0528d5d5
   ...
```