### PR TITLE
[Refactor #20] Commits 목록화 로직 통합

### DIFF
--- a/src/main/java/base/MiniGitCore.java
+++ b/src/main/java/base/MiniGitCore.java
@@ -95,19 +95,6 @@ public class MiniGitCore {
         return commitOid;
     }
 
-    public static void log(String startOid) {
-        String oid = startOid;
-        while (oid != null) {
-            Commit commit = getCommit(oid);
-
-            System.out.println("commit " + oid);
-            System.out.println("    " + commit.message.replace("\n", "\n    "));
-            System.out.println();
-
-            oid = commit.parent;
-        }
-    }
-
     public static Commit getCommit(String oid) {
         byte[] commitData = Repository.getObject(oid, "commit");
         if (commitData == null) {

--- a/src/main/java/base/MiniGitCore.java
+++ b/src/main/java/base/MiniGitCore.java
@@ -192,21 +192,23 @@ public class MiniGitCore {
     }
 
     public static List<String> listCommits(Set<String> oids) {
+        List<String> orderedCommits = new ArrayList<>();
         Set<String> visited = new HashSet<>();
-        Deque<String> stack = new ArrayDeque<>(oids);
-        while (!stack.isEmpty()) {
-            String oid = stack.pop();
+        Deque<String> queue = new ArrayDeque<>(oids);
+        while (!queue.isEmpty()) {
+            String oid = queue.pollFirst();
             if (oid == null || visited.contains(oid)) {
                 continue;
             }
             visited.add(oid);
+            orderedCommits.add(oid);
 
             Commit commit = getCommit(oid);
             if (commit.parent != null) {
-                stack.add(commit.parent);
+                queue.addFirst(commit.parent);
             }
         }
-        return new ArrayList<>(visited);
+        return orderedCommits;
     }
 
     private static void clearWorkingDirectory() {

--- a/src/main/java/cli/LogCommand.java
+++ b/src/main/java/cli/LogCommand.java
@@ -1,9 +1,13 @@
 package cli;
 
+import base.Commit;
 import base.MiniGitCore;
 import cli.converter.OidConverter;
 import data.Repository;
 import picocli.CommandLine;
+
+import java.util.List;
+import java.util.Set;
 
 @CommandLine.Command(name = "log", description = "Show commit history")
 public class LogCommand implements Runnable {
@@ -12,6 +16,12 @@ public class LogCommand implements Runnable {
 
     @Override
     public void run() {
-        MiniGitCore.log(oid);
+        List<String> commits = MiniGitCore.listCommits(Set.of(oid));
+        for (String commitOid : commits) {
+            Commit commit = MiniGitCore.getCommit(commitOid);
+            System.out.println("commit " + commitOid);
+            System.out.println("    " + commit.message.replace("\n", "\n    "));
+            System.out.println();
+        }
     }
 }


### PR DESCRIPTION
# 📝 작업 내용

### 1. LogCommand가 이용하는 log() 제거 + listCommits() 적용 및 개선
- listCommits()의 역할 > log()의 역할 : log 제거 후 listCommits() 적용 
- 명령어 결과 출력 로직 LogCommand로 이동
- listCommits()로부터 반환된 commit 목록이 순서를 보장하도록 개선
- 추후 구현할 병합 기능 고려하여 DFS -> BFS
```bash
# 예시 커밋 히스토리
A → B → C → D
      ↘
        E → F
```
```bash
# Stack(DFS) 사용 시 Commit 순서
commit A
commit B
commit C
commit D
commit E
commit F
```
```bash
# Queue(BFS) 사용 시 Commit 순서
commit A
commit B
commit C
commit E
commit D
commit F
```