### PR TITLE
[Feature #22] Symbolic Ref 기반 branch 기능 구현 & checkout 기능 확장

### DIFF
--- a/src/main/java/base/MiniGitCore.java
+++ b/src/main/java/base/MiniGitCore.java
@@ -90,7 +90,18 @@ public class MiniGitCore {
 
     public static String commit(String message) {
         String treeOid = writeTree(".");
-        String parentOid = Repository.getRef("HEAD").value();
+
+        RefValue headRef = Repository.getRef("HEAD", false);
+        String parentOid = null;
+        if(headRef != null && !headRef.symbolic()){
+            parentOid = headRef.value(); // detached HEAD
+        } else if(headRef != null){
+            RefValue derefHeadRef = Repository.getRef(headRef.value());
+            if(derefHeadRef != null){
+                parentOid = derefHeadRef.value(); // symbolic ref 역참조값
+            }
+        }
+
         String commitOid = commitObject(treeOid, parentOid, message);
         Repository.updateRef("HEAD", RefValue.direct(commitOid));
         return commitOid;

--- a/src/main/java/base/MiniGitCore.java
+++ b/src/main/java/base/MiniGitCore.java
@@ -93,11 +93,11 @@ public class MiniGitCore {
 
         RefValue headRef = Repository.getRef("HEAD", false);
         String parentOid = null;
-        if(headRef != null && !headRef.symbolic()){
+        if (headRef != null && !headRef.symbolic()) {
             parentOid = headRef.value(); // detached HEAD
-        } else if(headRef != null){
+        } else if (headRef != null) {
             RefValue derefHeadRef = Repository.getRef(headRef.value());
-            if(derefHeadRef != null){
+            if (derefHeadRef != null) {
                 parentOid = derefHeadRef.value(); // symbolic ref 역참조값
             }
         }
@@ -155,9 +155,9 @@ public class MiniGitCore {
         readTree(commit.tree);
 
         RefValue head;
-        if(isBranch(name)){
+        if (isBranch(name)) {
             head = RefValue.symbolic("refs/heads/" + name);
-        } else{
+        } else {
             head = RefValue.direct(oid);
         }
 
@@ -187,7 +187,7 @@ public class MiniGitCore {
 
         for (String ref : refsToTry) {
             RefValue refValue = Repository.getRef(ref);
-            if(refValue == null){
+            if (refValue == null) {
                 continue;
             }
 
@@ -228,7 +228,7 @@ public class MiniGitCore {
         Repository.updateRef("refs/heads/" + name, RefValue.direct(oid));
     }
 
-    private static boolean isBranch(String name){
+    private static boolean isBranch(String name) {
         RefValue ref = Repository.getRef("refs/heads/" + name, false);
         return ref != null;
     }

--- a/src/main/java/base/MiniGitCore.java
+++ b/src/main/java/base/MiniGitCore.java
@@ -153,8 +153,9 @@ public class MiniGitCore {
         }
         String[] refsToTry = {
                 name,                       // ex) HEAD, refs/tags/tag1 (전체 경로)
-                "refs/" + name,             // ex) tags/tag1
-                "refs/tags/" + name         // ex) tag1
+                "refs/" + name,             // ex) tags/tag1, heads/branch1
+                "refs/tags/" + name,        // ex) tag1
+                "refs/heads/" + name        // ex) branch1
         };
 
         for (String ref : refsToTry) {
@@ -194,6 +195,10 @@ public class MiniGitCore {
             }
         }
         return orderedCommits;
+    }
+
+    public static void createBranch(String name, String oid) {
+        Repository.updateRef("refs/heads/" + name, oid);
     }
 
     private static String commitObject(String treeOid, String parentOid, String message) {

--- a/src/main/java/base/MiniGitCore.java
+++ b/src/main/java/base/MiniGitCore.java
@@ -137,10 +137,19 @@ public class MiniGitCore {
         return new Commit(tree, parent, message.toString().trim());
     }
 
-    public static void checkout(String oid) {
+    public static void checkout(String name) {
+        String oid = getOid(name);
         Commit commit = getCommit(oid);
         readTree(commit.tree);
-        Repository.updateRef("HEAD", RefValue.direct(oid));
+
+        RefValue head;
+        if(isBranch(name)){
+            head = RefValue.symbolic("refs/heads/" + name);
+        } else{
+            head = RefValue.direct(oid);
+        }
+
+        Repository.updateRef("HEAD", head, false);
     }
 
     public static void createTag(String name, String oid) {
@@ -205,6 +214,11 @@ public class MiniGitCore {
 
     public static void createBranch(String name, String oid) {
         Repository.updateRef("refs/heads/" + name, RefValue.direct(oid));
+    }
+
+    private static boolean isBranch(String name){
+        RefValue ref = Repository.getRef("refs/heads/" + name, false);
+        return ref != null;
     }
 
     private static String commitObject(String treeOid, String parentOid, String message) {

--- a/src/main/java/base/MiniGitCore.java
+++ b/src/main/java/base/MiniGitCore.java
@@ -151,6 +151,12 @@ public class MiniGitCore {
         if (name.equals("@")) {
             name = "HEAD";
         }
+
+        // SHA-1 해시인지 확인
+        if (name.matches("^[a-fA-F0-9]{40}$")) {
+            return name;
+        }
+
         String[] refsToTry = {
                 name,                       // ex) HEAD, refs/tags/tag1 (전체 경로)
                 "refs/" + name,             // ex) tags/tag1, heads/branch1
@@ -159,15 +165,15 @@ public class MiniGitCore {
         };
 
         for (String ref : refsToTry) {
-            String oid = Repository.getRef(ref).value();
-            if (oid != null) {
-                return oid;
+            RefValue refValue = Repository.getRef(ref);
+            if(refValue == null){
+                continue;
             }
-        }
 
-        // SHA-1 해시인지 확인
-        if (name.matches("^[a-fA-F0-9]{40}$")) {
-            return name;
+            if (refValue.symbolic()) {
+                return Repository.getRef(ref).value();
+            }
+            return refValue.value();
         }
 
         throw new IllegalArgumentException("Unknown ref or OID: " + name);

--- a/src/main/java/base/MiniGitCore.java
+++ b/src/main/java/base/MiniGitCore.java
@@ -12,6 +12,7 @@ import java.util.*;
 public class MiniGitCore {
     public static void init() {
         Repository.init();
+        Repository.updateRef("HEAD", RefValue.symbolic("refs/heads/master"), false);
     }
 
     public static String hashObject(String filePath) {

--- a/src/main/java/base/MiniGitCore.java
+++ b/src/main/java/base/MiniGitCore.java
@@ -89,9 +89,9 @@ public class MiniGitCore {
 
     public static String commit(String message) {
         String treeOid = writeTree(".");
-        String parentOid = Repository.getRef("HEAD");
+        String parentOid = Repository.getRef("HEAD").value();
         String commitOid = commitObject(treeOid, parentOid, message);
-        Repository.updateRef("HEAD", commitOid);
+        Repository.updateRef("HEAD", RefValue.direct(commitOid));
         return commitOid;
     }
 
@@ -140,11 +140,11 @@ public class MiniGitCore {
     public static void checkout(String oid) {
         Commit commit = getCommit(oid);
         readTree(commit.tree);
-        Repository.updateRef("HEAD", oid);
+        Repository.updateRef("HEAD", RefValue.direct(oid));
     }
 
     public static void createTag(String name, String oid) {
-        Repository.updateRef("refs/tags/" + name, oid);
+        Repository.updateRef("refs/tags/" + name, RefValue.direct(oid));
     }
 
     public static String getOid(String name) {
@@ -159,7 +159,7 @@ public class MiniGitCore {
         };
 
         for (String ref : refsToTry) {
-            String oid = Repository.getRef(ref);
+            String oid = Repository.getRef(ref).value();
             if (oid != null) {
                 return oid;
             }
@@ -198,7 +198,7 @@ public class MiniGitCore {
     }
 
     public static void createBranch(String name, String oid) {
-        Repository.updateRef("refs/heads/" + name, oid);
+        Repository.updateRef("refs/heads/" + name, RefValue.direct(oid));
     }
 
     private static String commitObject(String treeOid, String parentOid, String message) {

--- a/src/main/java/base/MiniGitCore.java
+++ b/src/main/java/base/MiniGitCore.java
@@ -172,21 +172,6 @@ public class MiniGitCore {
         throw new IllegalArgumentException("Unknown ref or OID: " + name);
     }
 
-    private static String commitObject(String treeOid, String parentOid, String message) {
-        String timestamp = ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-
-        StringBuilder commitData = new StringBuilder();
-        commitData.append("tree ").append(treeOid).append("\n");
-        if (parentOid != null) {
-            commitData.append("parent ").append(parentOid).append("\n");
-        }
-        commitData.append("author MiniGit User\n");
-        commitData.append("time ").append(timestamp).append("\n\n");
-        commitData.append(message).append("\n");
-
-        return Repository.hashObject(commitData.toString(), "commit");
-    }
-
     public static Map<String, String> listRefs() {
         return Repository.iterRefs();
     }
@@ -209,6 +194,21 @@ public class MiniGitCore {
             }
         }
         return orderedCommits;
+    }
+
+    private static String commitObject(String treeOid, String parentOid, String message) {
+        String timestamp = ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+
+        StringBuilder commitData = new StringBuilder();
+        commitData.append("tree ").append(treeOid).append("\n");
+        if (parentOid != null) {
+            commitData.append("parent ").append(parentOid).append("\n");
+        }
+        commitData.append("author MiniGit User\n");
+        commitData.append("time ").append(timestamp).append("\n\n");
+        commitData.append(message).append("\n");
+
+        return Repository.hashObject(commitData.toString(), "commit");
     }
 
     private static void clearWorkingDirectory() {

--- a/src/main/java/base/MiniGitCore.java
+++ b/src/main/java/base/MiniGitCore.java
@@ -173,7 +173,7 @@ public class MiniGitCore {
         throw new IllegalArgumentException("Unknown ref or OID: " + name);
     }
 
-    public static Map<String, String> listRefs() {
+    public static Map<String, RefValue> listRefs() {
         return Repository.iterRefs();
     }
 

--- a/src/main/java/base/RefValue.java
+++ b/src/main/java/base/RefValue.java
@@ -1,0 +1,11 @@
+package base;
+
+public record RefValue(boolean symbolic, String value) {
+    public static RefValue symbolic(String refName) {
+        return new RefValue(true, refName);
+    }
+
+    public static RefValue direct(String oid) {
+        return new RefValue(false, oid);
+    }
+}

--- a/src/main/java/cli/BranchCommand.java
+++ b/src/main/java/cli/BranchCommand.java
@@ -1,5 +1,6 @@
 package cli;
 
+import base.MiniGitCore;
 import cli.converter.OidConverter;
 import picocli.CommandLine;
 
@@ -13,6 +14,7 @@ public class BranchCommand implements Runnable {
 
     @Override
     public void run() {
-        // MiniGitCore 메서드
+        MiniGitCore.createBranch(name, startPoint);
+        System.out.println("Branch " + name + " created at " + startPoint);
     }
 }

--- a/src/main/java/cli/BranchCommand.java
+++ b/src/main/java/cli/BranchCommand.java
@@ -1,0 +1,18 @@
+package cli;
+
+import cli.converter.OidConverter;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "branch", description = "Create a new branch")
+public class BranchCommand implements Runnable {
+    @CommandLine.Parameters(index = "0", description = "Branch name")
+    private String name;
+
+    @CommandLine.Parameters(index = "1", description = "Start point", defaultValue = "@", converter = OidConverter.class)
+    private String startPoint;
+
+    @Override
+    public void run() {
+        // MiniGitCore 메서드
+    }
+}

--- a/src/main/java/cli/CLI.java
+++ b/src/main/java/cli/CLI.java
@@ -13,7 +13,8 @@ import picocli.CommandLine;
                 LogCommand.class,
                 CheckoutCommand.class,
                 TagCommand.class,
-                KCommand.class
+                KCommand.class,
+                BranchCommand.class
         })
 public class CLI {
     public static void run() {

--- a/src/main/java/cli/CheckoutCommand.java
+++ b/src/main/java/cli/CheckoutCommand.java
@@ -1,11 +1,10 @@
 package cli;
 
 import base.MiniGitCore;
-import cli.converter.OidConverter;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "checkout", description = "Checkout a commit and update HEAD")
-public class CheckoutCommand implements Runnable{
+public class CheckoutCommand implements Runnable {
     @CommandLine.Parameters(index = "0", description = "Commit OID or ref")
     private String oid;
 

--- a/src/main/java/cli/CheckoutCommand.java
+++ b/src/main/java/cli/CheckoutCommand.java
@@ -6,7 +6,7 @@ import picocli.CommandLine;
 
 @CommandLine.Command(name = "checkout", description = "Checkout a commit and update HEAD")
 public class CheckoutCommand implements Runnable{
-    @CommandLine.Parameters(index = "0", description = "Commit OID or ref", converter = OidConverter.class)
+    @CommandLine.Parameters(index = "0", description = "Commit OID or ref")
     private String oid;
 
     @Override

--- a/src/main/java/cli/KCommand.java
+++ b/src/main/java/cli/KCommand.java
@@ -2,23 +2,27 @@ package cli;
 
 import base.Commit;
 import base.MiniGitCore;
+import base.RefValue;
 import picocli.CommandLine;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @CommandLine.Command(name = "k", description = "show all refs")
 public class KCommand implements Runnable {
     @Override
     public void run() {
-        Map<String, String> refs = MiniGitCore.listRefs();
+        Map<String, RefValue> refs = MiniGitCore.listRefs();
+        Set<String> oids = new HashSet<>();
         System.out.println("--Refs--");
-        for (Map.Entry<String, String> ref : refs.entrySet()) {
-            System.out.println(ref.getKey() + " " + ref.getValue());
+        for (Map.Entry<String, RefValue> ref : refs.entrySet()) {
+            System.out.println(ref.getKey() + " " + ref.getValue().value());
+            oids.add(ref.getValue().value());
         }
 
-        List<String> commits = MiniGitCore.listCommits(new HashSet<>(refs.values()));
+        List<String> commits = MiniGitCore.listCommits(oids);
         System.out.println("\n--Commits--");
         for (String oid : commits) {
             System.out.println("Commit: " + oid);

--- a/src/main/java/cli/KCommand.java
+++ b/src/main/java/cli/KCommand.java
@@ -19,7 +19,9 @@ public class KCommand implements Runnable {
         System.out.println("--Refs--");
         for (Map.Entry<String, RefValue> ref : refs.entrySet()) {
             System.out.println(ref.getKey() + " " + ref.getValue().value());
-            oids.add(ref.getValue().value());
+            if (!ref.getValue().symbolic()) {
+                oids.add(ref.getValue().value());
+            }
         }
 
         List<String> commits = MiniGitCore.listCommits(oids);

--- a/src/main/java/data/RefInternal.java
+++ b/src/main/java/data/RefInternal.java
@@ -1,0 +1,6 @@
+package data;
+
+import base.RefValue;
+
+public record RefInternal(String ref, RefValue value) {
+}

--- a/src/main/java/data/Repository.java
+++ b/src/main/java/data/Repository.java
@@ -109,11 +109,16 @@ public class Repository {
 
     public static String getRef(String ref) {
         Path refPath = Paths.get(GIT_DIR, ref);
+        String value = null;
         if (!Files.exists(refPath) || Files.isDirectory(refPath)) {
             return null;
         }
         try {
-            return Files.readString(refPath).trim();
+            value = Files.readString(refPath).trim();
+            if (value != null && value.startsWith("ref:")) {
+                return getRef(value.substring(5));
+            }
+            return value;
         } catch (IOException e) {
             System.out.println("Error: Could not read ref " + ref);
             e.printStackTrace();

--- a/src/main/java/data/Repository.java
+++ b/src/main/java/data/Repository.java
@@ -105,7 +105,10 @@ public class Repository {
     public static void updateRef(String ref, RefValue value, boolean deref) {
         String target = ref;
         if (deref) {
-            target = getRefInternal(ref, deref).ref();
+            RefInternal refInternal = getRefInternal(ref, true);
+            if(refInternal != null){
+                target = refInternal.ref();
+            }
         }
 
         try {

--- a/src/main/java/data/Repository.java
+++ b/src/main/java/data/Repository.java
@@ -162,7 +162,7 @@ public class Repository {
     }
 
     public static Map<String, RefValue> iterRefs() {
-        return iterRefs(true);
+        return iterRefs(false);
     }
 
     public static Map<String, RefValue> iterRefs(boolean deref) {

--- a/src/main/java/data/Repository.java
+++ b/src/main/java/data/Repository.java
@@ -131,7 +131,11 @@ public class Repository {
     }
 
     public static RefValue getRef(String ref, boolean deref) {
-        return getRefInternal(ref, deref).value();
+        RefInternal internal = getRefInternal(ref, deref);
+        if(internal == null){
+            return null;
+        }
+        return internal.value();
     }
 
     public static RefInternal getRefInternal(String ref, boolean deref) {

--- a/src/main/java/data/Repository.java
+++ b/src/main/java/data/Repository.java
@@ -106,7 +106,7 @@ public class Repository {
         String target = ref;
         if (deref) {
             RefInternal refInternal = getRefInternal(ref, true);
-            if(refInternal != null){
+            if (refInternal != null) {
                 target = refInternal.ref();
             }
         }
@@ -117,7 +117,7 @@ public class Repository {
 
             if (value.symbolic()) {
                 Files.writeString(refPath, "ref: " + value.value().trim());
-            } else{
+            } else {
                 Files.writeString(refPath, value.value().trim());
             }
         } catch (IOException e) {
@@ -132,7 +132,7 @@ public class Repository {
 
     public static RefValue getRef(String ref, boolean deref) {
         RefInternal internal = getRefInternal(ref, deref);
-        if(internal == null){
+        if (internal == null) {
             return null;
         }
         return internal.value();

--- a/src/main/java/data/Repository.java
+++ b/src/main/java/data/Repository.java
@@ -154,13 +154,13 @@ public class Repository {
         return null;
     }
 
-    public static Map<String, String> iterRefs() {
+    public static Map<String, RefValue> iterRefs() {
         return iterRefs(true);
     }
 
-    public static Map<String, String> iterRefs(boolean deref) {
-        Map<String, String> refs = new HashMap<>();
-        String head = getRef("HEAD", deref).value();
+    public static Map<String, RefValue> iterRefs(boolean deref) {
+        Map<String, RefValue> refs = new HashMap<>();
+        RefValue head = getRef("HEAD", deref);
         if (head != null) {
             refs.put("HEAD", head);
         }
@@ -171,7 +171,7 @@ public class Repository {
                 Files.walk(refsPath).filter(Files::isRegularFile) // 파일만 찾음
                         .forEach(refFile -> {
                             String refName = refsPath.relativize(refFile).toString();
-                            String refValue = getRef("refs/" + refName, deref).value();
+                            RefValue refValue = getRef("refs/" + refName, deref);
                             if (refValue != null) {
                                 refs.put("refs/" + refName, refValue);
                             }

--- a/src/main/java/data/Repository.java
+++ b/src/main/java/data/Repository.java
@@ -99,6 +99,7 @@ public class Repository {
     }
 
     public static void updateRef(String ref, RefValue value) {
+        ref = getRefInternal(ref).ref();
         try {
             Path refPath = Paths.get(GIT_DIR, ref);
             Files.createDirectories(refPath.getParent());
@@ -114,6 +115,10 @@ public class Repository {
     }
 
     public static RefValue getRef(String ref) {
+        return getRefInternal(ref).value();
+    }
+
+    public static RefInternal getRefInternal(String ref) {
         Path refPath = Paths.get(GIT_DIR, ref);
         String value = null;
         if (!Files.exists(refPath) || Files.isDirectory(refPath)) {
@@ -122,9 +127,9 @@ public class Repository {
         try {
             value = Files.readString(refPath).trim();
             if (value != null && value.startsWith("ref:")) {
-                return getRef(value.substring(5));
+                return getRefInternal(value.substring(5));
             }
-            return RefValue.direct(value);
+            return new RefInternal(ref, RefValue.direct(value));
         } catch (IOException e) {
             System.out.println("Error: Could not read ref " + ref);
             e.printStackTrace();


### PR DESCRIPTION
# 📝 작업 내용

### 1. Symbolic Refs 개념 도입
- HEAD가 특정 커밋이 아닌 브랜치 가리킬 수 있도록 함
- refs 파일의 내용이 `ref:` 로 시작하면 symbolic refs
- Symbolic Refs는 참조를 참조 <-> Direct Refs는 OID 참조

### 2. Branch 명령어 구현
- 커밋 진행과 함께 나아가는 포인터를 생성하는 명령어
- 새로운 커밋 생성시 브랜치는 자동으로 이를 가리킴 -> 동적 tag처럼 동작
- HEAD가 이동하면 자동으로 업데이트
```bash
# HEAD에 브랜치 생성
./gradlew run --args="branch <branch-name>”
```
```bash
# 특정 커밋(or tag)에 브랜치 생성
./gradlew run --args="branch <branch-name> <start-point>”
```

### 3. Checkout 명령어 기능 확장
- 브랜치를 checkout하면 HEAD가 해당 브랜치를 참조 -> HEAD는 Symbolic Refs
- 다른 것(tag or OID)을 checkout하면 HEAD가 커밋 OID를 직접 참조 -> HEAD는 Direct Refs
  - 이러한 HEAD를 detached HEAD라고 표현함

>   Usually the HEAD file is a symbolic reference to the branch you’re currently on. By symbolic reference, we mean that unlike a normal reference, it contains a pointer to another reference.
> 
> However in some rare cases the HEAD file may contain the SHA-1 value of a Git object. This happens when you checkout a tag, commit, or remote branch, which puts your repository in ["detached HEAD"](https://git-scm.com/docs/git-checkout#_detached_head) state.

### 4. master(메인 브랜치) 초기 브랜치 설정
- init 시 HEAD를 ref: refs/heads/master로 설정 -> 시작부터 브랜치 상태
- 실제 master 브랜치 파일은 커밋할 때 생성

<br>

# 💡 고민해 볼 요소
### 1. 테스트 자동화 도입
- 구현 과정에서 새로운 기능이나 개념을 추가할 때 기존에 구현된 명령어를 활용
- 기존 로직을 재활용하거나 기반으로 확장하는 방식이 대부분 -> 기존 로직에 대한 수정 발생
- 이전에 정상 동작하던 명령어들에 대한 재검증 필요함
- 수동으로 테스트를 진행하고 있었으나, 명령어 다양해지면서 이 작업이 너무 번거로워짐 -> 테스트 자동화 고려
