### PR TITLE
[Test #25] 테스트 utility 구현 & JUnit5 gradle 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,4 +12,9 @@ repositories {
 
 dependencies {
     implementation 'info.picocli:picocli:4.7.6'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src/test/java/base/BaseGitTest.java
+++ b/src/test/java/base/BaseGitTest.java
@@ -1,0 +1,20 @@
+package base;
+
+import data.Repository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+public abstract class BaseGitTest {
+    @TempDir
+    protected Path tempDir;       // 임시 디렉터리
+    protected Path workingDir;    // 실제 작업 디렉터리
+
+    @BeforeEach
+    void initRepo() {
+        workingDir = tempDir.resolve("repo");
+        System.setProperty("user.dir", workingDir.toString());  // 작업 디렉토리를 강제로 설정
+        Repository.init();
+    }
+}

--- a/src/test/java/util/TestUtils.java
+++ b/src/test/java/util/TestUtils.java
@@ -1,0 +1,26 @@
+package util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class TestUtils {
+    public static void writeFile(Path dir, String name, String content) throws IOException {
+        Path file = dir.resolve(name);
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, content);
+    }
+
+    public static String readFile(Path dir, String name) throws IOException {
+        Path file = dir.resolve(name);
+        return Files.readString(file);
+    }
+
+    public static boolean fileExists(Path dir, String name) {
+        return Files.exists(dir.resolve(name));
+    }
+
+    public static void deleteFile(Path dir, String name) throws IOException {
+        Files.deleteIfExists(dir.resolve(name));
+    }
+}


### PR DESCRIPTION
# 📝 작업 내용

### 1. 공통 초기화 추상 클래스 구현
  - `@TempDir` 기반 임시 디렉토리 구성
```bash
/tmp/junit16624071649911791120/repo/.miniGit/
```

### 2. Gradle 설정에서 JUnit 5 기반 테스트 정상 실행
```bash
./gradlew test
```